### PR TITLE
validation extention

### DIFF
--- a/samples/Aegis.Auth.Sample/Program.cs
+++ b/samples/Aegis.Auth.Sample/Program.cs
@@ -35,6 +35,8 @@ builder.Services.AddAegisAuth<SampleAuthDbContext>(options =>
     };
 });
 
+builder.Services.AddAegisAuthAuthentication();
+
 builder.Services.AddControllers();
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
@@ -57,6 +59,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();

--- a/src/Aegis.Auth/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aegis.Auth/Extensions/ServiceCollectionExtensions.cs
@@ -3,9 +3,11 @@ using Aegis.Auth.Features.Sessions;
 using Aegis.Auth.Features.SignIn;
 using Aegis.Auth.Features.SignOut;
 using Aegis.Auth.Features.SignUp;
+using Aegis.Auth.Infrastructure.Authentication;
 using Aegis.Auth.Infrastructure.Cookies;
 using Aegis.Auth.Options;
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
@@ -40,6 +42,22 @@ namespace Aegis.Auth.Extensions
             services.AddScoped<ISignUpService, SignUpService>();
             services.AddScoped<ISignOutService, SignOutService>();
 
+            return services;
+        }
+
+        public static IServiceCollection AddAegisAuthAuthentication(
+            this IServiceCollection services,
+            string authenticationScheme = AegisAuthenticationDefaults.AuthenticationScheme)
+        {
+            services
+                .AddAuthentication(options =>
+                {
+                    options.DefaultAuthenticateScheme = authenticationScheme;
+                    options.DefaultChallengeScheme = authenticationScheme;
+                })
+                .AddScheme<AuthenticationSchemeOptions, AegisAuthenticationHandler>(authenticationScheme, _ => { });
+
+            services.AddAuthorization();
             return services;
         }
     }

--- a/src/Aegis.Auth/Features/Sessions/SessionService.cs
+++ b/src/Aegis.Auth/Features/Sessions/SessionService.cs
@@ -116,7 +116,7 @@ namespace Aegis.Auth.Features.Sessions
                             var verifyJson = await _cache.GetStringAsync(registryKey);
                             if (!string.IsNullOrWhiteSpace(verifyJson))
                             {
-                                var verifyList = JsonSerializer.Deserialize<List<SessionReference>>(verifyJson);
+                                List<SessionReference>? verifyList = JsonSerializer.Deserialize<List<SessionReference>>(verifyJson);
                                 if (verifyList?.Any(s => s.Token == data.Token) == true)
                                 {
                                     registryUpdated = true;

--- a/src/Aegis.Auth/Features/SignOut/SignOutController.cs
+++ b/src/Aegis.Auth/Features/SignOut/SignOutController.cs
@@ -1,12 +1,15 @@
 using Aegis.Auth.Abstractions;
+using Aegis.Auth.Infrastructure.Authentication;
 using Aegis.Auth.Infrastructure.Cookies;
 
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Aegis.Auth.Features.SignOut
 {
     [ApiController]
     [Route("api/auth")]
+    [Authorize(AuthenticationSchemes = AegisAuthenticationDefaults.AuthenticationScheme)]
     public sealed class SignOutController(ISignOutService signOutService, SessionCookieHandler cookieHandler) : AegisControllerBase
     {
         private readonly SessionCookieHandler _cookieHandler = cookieHandler;

--- a/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationDefaults.cs
+++ b/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationDefaults.cs
@@ -1,0 +1,7 @@
+namespace Aegis.Auth.Infrastructure.Authentication
+{
+  public static class AegisAuthenticationDefaults
+  {
+    public const string AuthenticationScheme = "AegisSession";
+  }
+}

--- a/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationDefaults.cs
+++ b/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationDefaults.cs
@@ -1,7 +1,7 @@
 namespace Aegis.Auth.Infrastructure.Authentication
 {
-  public static class AegisAuthenticationDefaults
-  {
-    public const string AuthenticationScheme = "AegisSession";
-  }
+    public static class AegisAuthenticationDefaults
+    {
+        public const string AuthenticationScheme = "AegisSession";
+    }
 }

--- a/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationHandler.cs
+++ b/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationHandler.cs
@@ -1,0 +1,134 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+using Aegis.Auth.Abstractions;
+using Aegis.Auth.Entities;
+using Aegis.Auth.Features.Sessions;
+using Aegis.Auth.Infrastructure.Cookies;
+using Aegis.Auth.Options;
+
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Aegis.Auth.Infrastructure.Authentication
+{
+  internal sealed class AegisAuthenticationHandler(
+      IOptionsMonitor<AuthenticationSchemeOptions> options,
+      ILoggerFactory logger,
+      UrlEncoder encoder,
+      IAuthDbContext dbContext,
+      SessionCookieHandler cookieHandler,
+      AegisAuthOptions authOptions,
+      IDistributedCache? cache = null) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+  {
+    private readonly IAuthDbContext _dbContext = dbContext;
+    private readonly SessionCookieHandler _cookieHandler = cookieHandler;
+    private readonly AegisAuthOptions _authOptions = authOptions;
+    private readonly IDistributedCache? _cache = cache;
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+      var token = _cookieHandler.GetSessionToken(Context);
+      if (string.IsNullOrWhiteSpace(token))
+        return AuthenticateResult.NoResult();
+
+      SessionPrincipalData? principalData = await TryResolveSessionFromCacheAsync(token);
+      principalData ??= await TryResolveSessionFromDatabaseAsync(token);
+
+      if (principalData is null)
+        return AuthenticateResult.Fail("Invalid or expired session.");
+
+      var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, principalData.UserId),
+                new(ClaimTypes.Email, principalData.Email),
+                new("aegis:session_id", principalData.SessionId),
+                new("aegis:email_verified", principalData.EmailVerified ? "true" : "false")
+            };
+
+      if (string.IsNullOrWhiteSpace(principalData.Name) is false)
+        claims.Add(new Claim(ClaimTypes.Name, principalData.Name));
+
+      var identity = new ClaimsIdentity(claims, Scheme.Name);
+      var principal = new ClaimsPrincipal(identity);
+      var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+      return AuthenticateResult.Success(ticket);
+    }
+
+    private async Task<SessionPrincipalData?> TryResolveSessionFromCacheAsync(string token)
+    {
+      if (_cache is null)
+        return null;
+
+      var sessionJson = await _cache.GetStringAsync(token, Context.RequestAborted);
+      if (string.IsNullOrWhiteSpace(sessionJson))
+        return null;
+
+      SessionCacheJson? sessionCache;
+      try
+      {
+        sessionCache = JsonSerializer.Deserialize<SessionCacheJson>(sessionJson);
+      }
+      catch
+      {
+        return null;
+      }
+
+      if (sessionCache?.Session is null || sessionCache.User is null)
+        return null;
+
+      if (sessionCache.Session.ExpiresAt <= DateTime.UtcNow)
+        return null;
+
+      return new SessionPrincipalData
+      {
+        SessionId = sessionCache.Session.Id,
+        UserId = sessionCache.User.Id,
+        Email = sessionCache.User.Email,
+        Name = sessionCache.User.Name,
+        EmailVerified = sessionCache.User.EmailVerified
+      };
+    }
+
+    private async Task<SessionPrincipalData?> TryResolveSessionFromDatabaseAsync(string token)
+    {
+      if (_authOptions.Session.StoreSessionInDatabase is false && _cache is not null)
+        return null;
+
+      Session? session = await _dbContext.Sessions.AsNoTracking()
+    .FirstOrDefaultAsync(s => s.Token == token, Context.RequestAborted);
+
+      if (session is null || session.ExpiresAt <= DateTime.UtcNow)
+        return null;
+
+      User? user = await _dbContext.Users.AsNoTracking()
+    .FirstOrDefaultAsync(u => u.Id == session.UserId, Context.RequestAborted);
+
+      if (user is null)
+        return null;
+
+      return new SessionPrincipalData
+      {
+        SessionId = session.Id,
+        UserId = user.Id,
+        Email = user.Email,
+        Name = user.Name,
+        EmailVerified = user.EmailVerified
+      };
+    }
+
+    private sealed class SessionPrincipalData
+    {
+      public required string SessionId { get; init; }
+      public required string UserId { get; init; }
+      public required string Email { get; init; }
+      public string? Name { get; init; }
+      public bool EmailVerified { get; init; }
+    }
+  }
+}

--- a/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationHandler.cs
+++ b/src/Aegis.Auth/Infrastructure/Authentication/AegisAuthenticationHandler.cs
@@ -16,33 +16,33 @@ using Microsoft.Extensions.Options;
 
 namespace Aegis.Auth.Infrastructure.Authentication
 {
-  internal sealed class AegisAuthenticationHandler(
-      IOptionsMonitor<AuthenticationSchemeOptions> options,
-      ILoggerFactory logger,
-      UrlEncoder encoder,
-      IAuthDbContext dbContext,
-      SessionCookieHandler cookieHandler,
-      AegisAuthOptions authOptions,
-      IDistributedCache? cache = null) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
-  {
-    private readonly IAuthDbContext _dbContext = dbContext;
-    private readonly SessionCookieHandler _cookieHandler = cookieHandler;
-    private readonly AegisAuthOptions _authOptions = authOptions;
-    private readonly IDistributedCache? _cache = cache;
-
-    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    internal sealed class AegisAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IAuthDbContext dbContext,
+        SessionCookieHandler cookieHandler,
+        AegisAuthOptions authOptions,
+        IDistributedCache? cache = null) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
     {
-      var token = _cookieHandler.GetSessionToken(Context);
-      if (string.IsNullOrWhiteSpace(token))
-        return AuthenticateResult.NoResult();
+        private readonly IAuthDbContext _dbContext = dbContext;
+        private readonly SessionCookieHandler _cookieHandler = cookieHandler;
+        private readonly AegisAuthOptions _authOptions = authOptions;
+        private readonly IDistributedCache? _cache = cache;
 
-      SessionPrincipalData? principalData = await TryResolveSessionFromCacheAsync(token);
-      principalData ??= await TryResolveSessionFromDatabaseAsync(token);
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var token = _cookieHandler.GetSessionToken(Context);
+            if (string.IsNullOrWhiteSpace(token))
+                return AuthenticateResult.NoResult();
 
-      if (principalData is null)
-        return AuthenticateResult.Fail("Invalid or expired session.");
+            SessionPrincipalData? principalData = await TryResolveSessionFromCacheAsync(token);
+            principalData ??= await TryResolveSessionFromDatabaseAsync(token);
 
-      var claims = new List<Claim>
+            if (principalData is null)
+                return AuthenticateResult.Fail("Invalid or expired session.");
+
+            var claims = new List<Claim>
             {
                 new(ClaimTypes.NameIdentifier, principalData.UserId),
                 new(ClaimTypes.Email, principalData.Email),
@@ -50,85 +50,85 @@ namespace Aegis.Auth.Infrastructure.Authentication
                 new("aegis:email_verified", principalData.EmailVerified ? "true" : "false")
             };
 
-      if (string.IsNullOrWhiteSpace(principalData.Name) is false)
-        claims.Add(new Claim(ClaimTypes.Name, principalData.Name));
+            if (string.IsNullOrWhiteSpace(principalData.Name) is false)
+                claims.Add(new Claim(ClaimTypes.Name, principalData.Name));
 
-      var identity = new ClaimsIdentity(claims, Scheme.Name);
-      var principal = new ClaimsPrincipal(identity);
-      var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            var identity = new ClaimsIdentity(claims, Scheme.Name);
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
 
-      return AuthenticateResult.Success(ticket);
+            return AuthenticateResult.Success(ticket);
+        }
+
+        private async Task<SessionPrincipalData?> TryResolveSessionFromCacheAsync(string token)
+        {
+            if (_cache is null)
+                return null;
+
+            var sessionJson = await _cache.GetStringAsync(token, Context.RequestAborted);
+            if (string.IsNullOrWhiteSpace(sessionJson))
+                return null;
+
+            SessionCacheJson? sessionCache;
+            try
+            {
+                sessionCache = JsonSerializer.Deserialize<SessionCacheJson>(sessionJson);
+            }
+            catch
+            {
+                return null;
+            }
+
+            if (sessionCache?.Session is null || sessionCache.User is null)
+                return null;
+
+            if (sessionCache.Session.ExpiresAt <= DateTime.UtcNow)
+                return null;
+
+            return new SessionPrincipalData
+            {
+                SessionId = sessionCache.Session.Id,
+                UserId = sessionCache.User.Id,
+                Email = sessionCache.User.Email,
+                Name = sessionCache.User.Name,
+                EmailVerified = sessionCache.User.EmailVerified
+            };
+        }
+
+        private async Task<SessionPrincipalData?> TryResolveSessionFromDatabaseAsync(string token)
+        {
+            if (_authOptions.Session.StoreSessionInDatabase is false && _cache is not null)
+                return null;
+
+            Session? session = await _dbContext.Sessions.AsNoTracking()
+          .FirstOrDefaultAsync(s => s.Token == token, Context.RequestAborted);
+
+            if (session is null || session.ExpiresAt <= DateTime.UtcNow)
+                return null;
+
+            User? user = await _dbContext.Users.AsNoTracking()
+          .FirstOrDefaultAsync(u => u.Id == session.UserId, Context.RequestAborted);
+
+            if (user is null)
+                return null;
+
+            return new SessionPrincipalData
+            {
+                SessionId = session.Id,
+                UserId = user.Id,
+                Email = user.Email,
+                Name = user.Name,
+                EmailVerified = user.EmailVerified
+            };
+        }
+
+        private sealed class SessionPrincipalData
+        {
+            public required string SessionId { get; init; }
+            public required string UserId { get; init; }
+            public required string Email { get; init; }
+            public string? Name { get; init; }
+            public bool EmailVerified { get; init; }
+        }
     }
-
-    private async Task<SessionPrincipalData?> TryResolveSessionFromCacheAsync(string token)
-    {
-      if (_cache is null)
-        return null;
-
-      var sessionJson = await _cache.GetStringAsync(token, Context.RequestAborted);
-      if (string.IsNullOrWhiteSpace(sessionJson))
-        return null;
-
-      SessionCacheJson? sessionCache;
-      try
-      {
-        sessionCache = JsonSerializer.Deserialize<SessionCacheJson>(sessionJson);
-      }
-      catch
-      {
-        return null;
-      }
-
-      if (sessionCache?.Session is null || sessionCache.User is null)
-        return null;
-
-      if (sessionCache.Session.ExpiresAt <= DateTime.UtcNow)
-        return null;
-
-      return new SessionPrincipalData
-      {
-        SessionId = sessionCache.Session.Id,
-        UserId = sessionCache.User.Id,
-        Email = sessionCache.User.Email,
-        Name = sessionCache.User.Name,
-        EmailVerified = sessionCache.User.EmailVerified
-      };
-    }
-
-    private async Task<SessionPrincipalData?> TryResolveSessionFromDatabaseAsync(string token)
-    {
-      if (_authOptions.Session.StoreSessionInDatabase is false && _cache is not null)
-        return null;
-
-      Session? session = await _dbContext.Sessions.AsNoTracking()
-    .FirstOrDefaultAsync(s => s.Token == token, Context.RequestAborted);
-
-      if (session is null || session.ExpiresAt <= DateTime.UtcNow)
-        return null;
-
-      User? user = await _dbContext.Users.AsNoTracking()
-    .FirstOrDefaultAsync(u => u.Id == session.UserId, Context.RequestAborted);
-
-      if (user is null)
-        return null;
-
-      return new SessionPrincipalData
-      {
-        SessionId = session.Id,
-        UserId = user.Id,
-        Email = user.Email,
-        Name = user.Name,
-        EmailVerified = user.EmailVerified
-      };
-    }
-
-    private sealed class SessionPrincipalData
-    {
-      public required string SessionId { get; init; }
-      public required string UserId { get; init; }
-      public required string Email { get; init; }
-      public string? Name { get; init; }
-      public bool EmailVerified { get; init; }
-    }
-  }
 }

--- a/tests/Aegis.Auth.Tests/Aegis.Auth.Tests.csproj
+++ b/tests/Aegis.Auth.Tests/Aegis.Auth.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="8.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Aegis.Auth\Aegis.Auth.csproj" />
+    <ProjectReference Include="..\..\samples\Aegis.Auth.Sample\Aegis.Auth.Sample.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Aegis.Auth.Tests/Features/AuthorizationControllerTests.cs
+++ b/tests/Aegis.Auth.Tests/Features/AuthorizationControllerTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Aegis.Auth.Tests.Features
+{
+  public class AuthorizationControllerTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
+  {
+    private readonly WebApplicationFactory<Program> _factory = factory;
+
+    [Fact]
+    public async Task SignOut_RequiresAuthorization()
+    {
+      // Arrange
+      HttpClient client = _factory.CreateClient();
+
+      // Act
+      HttpResponseMessage response = await client.PostAsync("/api/auth/sign-out", null);
+
+      // Assert
+      Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SignOut_WithValidSessionCookie_ReturnsOk()
+    {
+      HttpClient client = _factory.CreateClient();
+
+      var signInResponse = await client.PostAsJsonAsync("/api/auth/sign-in/email", new
+      {
+        Email = "test@example.com",
+        Password = "Password123!",
+        RememberMe = true
+      });
+
+      Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
+
+      HttpResponseMessage signOutResponse = await client.PostAsync("/api/auth/sign-out", null);
+
+      Assert.Equal(HttpStatusCode.OK, signOutResponse.StatusCode);
+    }
+  }
+}

--- a/tests/Aegis.Auth.Tests/Features/AuthorizationControllerTests.cs
+++ b/tests/Aegis.Auth.Tests/Features/AuthorizationControllerTests.cs
@@ -5,40 +5,40 @@ using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace Aegis.Auth.Tests.Features
 {
-  public class AuthorizationControllerTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
-  {
-    private readonly WebApplicationFactory<Program> _factory = factory;
-
-    [Fact]
-    public async Task SignOut_RequiresAuthorization()
+    public class AuthorizationControllerTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
     {
-      // Arrange
-      HttpClient client = _factory.CreateClient();
+        private readonly WebApplicationFactory<Program> _factory = factory;
 
-      // Act
-      HttpResponseMessage response = await client.PostAsync("/api/auth/sign-out", null);
+        [Fact]
+        public async Task SignOut_RequiresAuthorization()
+        {
+            // Arrange
+            HttpClient client = _factory.CreateClient();
 
-      // Assert
-      Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+            // Act
+            HttpResponseMessage response = await client.PostAsync("/api/auth/sign-out", null);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task SignOut_WithValidSessionCookie_ReturnsOk()
+        {
+            HttpClient client = _factory.CreateClient();
+
+            var signInResponse = await client.PostAsJsonAsync("/api/auth/sign-in/email", new
+            {
+                Email = "test@example.com",
+                Password = "Password123!",
+                RememberMe = true
+            });
+
+            Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
+
+            HttpResponseMessage signOutResponse = await client.PostAsync("/api/auth/sign-out", null);
+
+            Assert.Equal(HttpStatusCode.OK, signOutResponse.StatusCode);
+        }
     }
-
-    [Fact]
-    public async Task SignOut_WithValidSessionCookie_ReturnsOk()
-    {
-      HttpClient client = _factory.CreateClient();
-
-      var signInResponse = await client.PostAsJsonAsync("/api/auth/sign-in/email", new
-      {
-        Email = "test@example.com",
-        Password = "Password123!",
-        RememberMe = true
-      });
-
-      Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
-
-      HttpResponseMessage signOutResponse = await client.PostAsync("/api/auth/sign-out", null);
-
-      Assert.Equal(HttpStatusCode.OK, signOutResponse.StatusCode);
-    }
-  }
 }

--- a/tests/Aegis.Auth.Tests/Features/AuthorizationControllerTests.cs
+++ b/tests/Aegis.Auth.Tests/Features/AuthorizationControllerTests.cs
@@ -3,42 +3,41 @@ using System.Net.Http.Json;
 
 using Microsoft.AspNetCore.Mvc.Testing;
 
-namespace Aegis.Auth.Tests.Features
+namespace Aegis.Auth.Tests.Features;
+
+public sealed class AuthorizationControllerTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
 {
-    public class AuthorizationControllerTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
+    private readonly WebApplicationFactory<Program> _factory = factory;
+
+    [Fact]
+    public async Task SignOut_RequiresAuthorization()
     {
-        private readonly WebApplicationFactory<Program> _factory = factory;
+        // Arrange
+        HttpClient client = _factory.CreateClient();
 
-        [Fact]
-        public async Task SignOut_RequiresAuthorization()
+        // Act
+        HttpResponseMessage response = await client.PostAsync("/api/auth/sign-out", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SignOut_WithValidSessionCookie_ReturnsOk()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        var signInResponse = await client.PostAsJsonAsync("/api/auth/sign-in/email", new
         {
-            // Arrange
-            HttpClient client = _factory.CreateClient();
+            Email = "test@example.com",
+            Password = "Password123!",
+            RememberMe = true
+        });
 
-            // Act
-            HttpResponseMessage response = await client.PostAsync("/api/auth/sign-out", null);
+        Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
 
-            // Assert
-            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-        }
+        HttpResponseMessage signOutResponse = await client.PostAsync("/api/auth/sign-out", null);
 
-        [Fact]
-        public async Task SignOut_WithValidSessionCookie_ReturnsOk()
-        {
-            HttpClient client = _factory.CreateClient();
-
-            var signInResponse = await client.PostAsJsonAsync("/api/auth/sign-in/email", new
-            {
-                Email = "test@example.com",
-                Password = "Password123!",
-                RememberMe = true
-            });
-
-            Assert.Equal(HttpStatusCode.OK, signInResponse.StatusCode);
-
-            HttpResponseMessage signOutResponse = await client.PostAsync("/api/auth/sign-out", null);
-
-            Assert.Equal(HttpStatusCode.OK, signOutResponse.StatusCode);
-        }
+        Assert.Equal(HttpStatusCode.OK, signOutResponse.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary

Adds session-based authentication to Aegis.Auth via a custom authentication handler + defaults, wires it into the pipeline, and tightens sign-out to require authorization. Includes new/updated tests to cover the sign-out flow.

## Changes

- Add `AegisAuthenticationHandler` and `AegisAuthenticationDefaults` for session-based auth
- Add authentication middleware wiring + update session verification behavior
- Expose DI helper to register auth (`AddAegisAuthAuthentication`)
- Require authorization on `SignOutController`
- Add/adjust tests covering authorization and sign-out regression
- Minor CI + sample app wiring updates

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [ ] 📚 Documentation
- [x] 🧪 Tests
- [ ] 🔧 CI/CD
- [ ] 📦 Dependencies

## Testing

- [x] Unit tests pass (`dotnet test -c Release`) (167 passed)
- [x] Sample app builds (built as part of `dotnet test`)
- [ ] Manual testing performed
- [ ] No tests needed (docs/config only)

## Checklist

- [x] Code follows project conventions
- [ ] No warnings introduced (`-warnaserror` passes)
- [ ] Breaking changes are documented