### PR TITLE
feat: add reusable Aegis auth protection and auth context support

### DIFF
--- a/samples/Aegis.Auth.Sample/Controllers/ProjectsController.cs
+++ b/samples/Aegis.Auth.Sample/Controllers/ProjectsController.cs
@@ -22,7 +22,7 @@ public sealed class ProjectsController(SampleAuthDbContext context, IProjectWork
     [HttpGet("my")]
     public async Task<IActionResult> GetMyProjects(CancellationToken cancellationToken)
     {
-        string userId = GetRequiredUserId();
+        var userId = GetRequiredUserId();
 
         UserTierProfile? tierProfile = await _workspaceService.GetTierProfileAsync(userId, cancellationToken);
         if (tierProfile is null)
@@ -49,7 +49,7 @@ public sealed class ProjectsController(SampleAuthDbContext context, IProjectWork
     [HttpGet("my/workspace")]
     public async Task<IActionResult> GetMyWorkspace(CancellationToken cancellationToken)
     {
-        string userId = GetRequiredUserId();
+        var userId = GetRequiredUserId();
 
         UserTierProfile? tierProfile = await _workspaceService.GetTierProfileAsync(userId, cancellationToken);
         if (tierProfile is null)
@@ -85,7 +85,7 @@ public sealed class ProjectsController(SampleAuthDbContext context, IProjectWork
     [HttpPost]
     public async Task<IActionResult> CreateProject([FromBody] CreateProjectRequest request, CancellationToken cancellationToken)
     {
-        string userId = GetRequiredUserId();
+        var userId = GetRequiredUserId();
 
         if (string.IsNullOrWhiteSpace(request.Name))
         {
@@ -119,7 +119,7 @@ public sealed class ProjectsController(SampleAuthDbContext context, IProjectWork
     [HttpGet("{projectId}/tasks")]
     public async Task<IActionResult> GetProjectTasks(string projectId, CancellationToken cancellationToken)
     {
-        string userId = GetRequiredUserId();
+        var userId = GetRequiredUserId();
 
         ProjectTasksDto? project = await _workspaceService.GetProjectTasksAsync(userId, projectId, cancellationToken);
 
@@ -134,7 +134,7 @@ public sealed class ProjectsController(SampleAuthDbContext context, IProjectWork
     [HttpPost("{projectId}/tasks")]
     public async Task<IActionResult> AddTask(string projectId, [FromBody] AddTaskRequest request, CancellationToken cancellationToken)
     {
-        string userId = GetRequiredUserId();
+        var userId = GetRequiredUserId();
 
         if (string.IsNullOrWhiteSpace(request.Title))
         {

--- a/samples/Aegis.Auth.Sample/Controllers/ProjectsController.cs
+++ b/samples/Aegis.Auth.Sample/Controllers/ProjectsController.cs
@@ -1,6 +1,8 @@
 using System.ComponentModel.DataAnnotations;
 
-using Aegis.Auth.Infrastructure.Cookies;
+using Aegis.Auth.Abstractions;
+using Aegis.Auth.Entities;
+using Aegis.Auth.Extensions;
 using Aegis.Auth.Sample.Data;
 using Aegis.Auth.Sample.Services;
 
@@ -11,28 +13,24 @@ namespace Aegis.Auth.Sample.Controllers;
 
 [ApiController]
 [Route("api/projects")]
-public sealed class ProjectsController(SampleAuthDbContext context, SessionCookieHandler cookieHandler, IProjectWorkspaceService workspaceService) : ControllerBase
+[AegisAuthorize]
+public sealed class ProjectsController(SampleAuthDbContext context, IProjectWorkspaceService workspaceService) : ControllerBase
 {
     private readonly SampleAuthDbContext _context = context;
-    private readonly SessionCookieHandler _cookieHandler = cookieHandler;
     private readonly IProjectWorkspaceService _workspaceService = workspaceService;
 
     [HttpGet("my")]
     public async Task<IActionResult> GetMyProjects(CancellationToken cancellationToken)
     {
-        var userId = await ResolveUserIdAsync(cancellationToken);
-        if (userId is null)
-        {
-            return Unauthorized(new { message = "Sign in first to access your projects." });
-        }
+        string userId = GetRequiredUserId();
 
-        var tierProfile = await _workspaceService.GetTierProfileAsync(userId, cancellationToken);
+        UserTierProfile? tierProfile = await _workspaceService.GetTierProfileAsync(userId, cancellationToken);
         if (tierProfile is null)
         {
             return Unauthorized(new { message = "Authenticated user was not found." });
         }
 
-        var projects = await _workspaceService.GetProjectsForUserAsync(userId, cancellationToken);
+        List<ProjectSummaryDto> projects = await _workspaceService.GetProjectsForUserAsync(userId, cancellationToken);
 
         return Ok(new
         {
@@ -51,13 +49,9 @@ public sealed class ProjectsController(SampleAuthDbContext context, SessionCooki
     [HttpGet("my/workspace")]
     public async Task<IActionResult> GetMyWorkspace(CancellationToken cancellationToken)
     {
-        var userId = await ResolveUserIdAsync(cancellationToken);
-        if (userId is null)
-        {
-            return Unauthorized(new { message = "Sign in first to access workspace details." });
-        }
+        string userId = GetRequiredUserId();
 
-        var tierProfile = await _workspaceService.GetTierProfileAsync(userId, cancellationToken);
+        UserTierProfile? tierProfile = await _workspaceService.GetTierProfileAsync(userId, cancellationToken);
         if (tierProfile is null)
         {
             return Unauthorized(new { message = "Authenticated user was not found." });
@@ -91,18 +85,14 @@ public sealed class ProjectsController(SampleAuthDbContext context, SessionCooki
     [HttpPost]
     public async Task<IActionResult> CreateProject([FromBody] CreateProjectRequest request, CancellationToken cancellationToken)
     {
-        var userId = await ResolveUserIdAsync(cancellationToken);
-        if (userId is null)
-        {
-            return Unauthorized(new { message = "Sign in first to create projects." });
-        }
+        string userId = GetRequiredUserId();
 
         if (string.IsNullOrWhiteSpace(request.Name))
         {
             return BadRequest(new { message = "Project name is required." });
         }
 
-        var createdProject = await _workspaceService.CreateProjectAsync(
+        CreateProjectResult? createdProject = await _workspaceService.CreateProjectAsync(
             userId,
             request.Name,
             request.Description,
@@ -129,13 +119,9 @@ public sealed class ProjectsController(SampleAuthDbContext context, SessionCooki
     [HttpGet("{projectId}/tasks")]
     public async Task<IActionResult> GetProjectTasks(string projectId, CancellationToken cancellationToken)
     {
-        var userId = await ResolveUserIdAsync(cancellationToken);
-        if (userId is null)
-        {
-            return Unauthorized(new { message = "Sign in first to access project tasks." });
-        }
+        string userId = GetRequiredUserId();
 
-        var project = await _workspaceService.GetProjectTasksAsync(userId, projectId, cancellationToken);
+        ProjectTasksDto? project = await _workspaceService.GetProjectTasksAsync(userId, projectId, cancellationToken);
 
         if (project is null)
         {
@@ -148,18 +134,14 @@ public sealed class ProjectsController(SampleAuthDbContext context, SessionCooki
     [HttpPost("{projectId}/tasks")]
     public async Task<IActionResult> AddTask(string projectId, [FromBody] AddTaskRequest request, CancellationToken cancellationToken)
     {
-        var userId = await ResolveUserIdAsync(cancellationToken);
-        if (userId is null)
-        {
-            return Unauthorized(new { message = "Sign in first to add tasks." });
-        }
+        string userId = GetRequiredUserId();
 
         if (string.IsNullOrWhiteSpace(request.Title))
         {
             return BadRequest(new { message = "Task title is required." });
         }
 
-        var createdTask = await _workspaceService.AddTaskAsync(userId, projectId, request.Title, cancellationToken);
+        AddProjectTaskResult? createdTask = await _workspaceService.AddTaskAsync(userId, projectId, request.Title, cancellationToken);
         if (createdTask is null)
         {
             return BadRequest(new
@@ -179,31 +161,13 @@ public sealed class ProjectsController(SampleAuthDbContext context, SessionCooki
         });
     }
 
-    private async Task<string?> ResolveUserIdAsync(CancellationToken cancellationToken)
+    private string GetRequiredUserId()
     {
-        // Fast path: use verified session_data cookie when present.
-        var userId = _cookieHandler.GetCookieCache(HttpContext)?.User.Id;
-        if (string.IsNullOrWhiteSpace(userId) is false)
-        {
-            return userId;
-        }
+        AegisAuthContext? authContext = HttpContext.GetAegisAuthContext();
+        if (authContext is null || string.IsNullOrWhiteSpace(authContext.UserId))
+            throw new InvalidOperationException("Aegis auth context is unavailable. Ensure [AegisAuthorize] is applied.");
 
-        var token = _cookieHandler.GetSessionToken(HttpContext);
-        if (string.IsNullOrWhiteSpace(token))
-        {
-            return null;
-        }
-
-        var session = await _context.Sessions
-            .AsNoTracking()
-            .FirstOrDefaultAsync(s => s.Token == token, cancellationToken);
-
-        if (session is null || session.ExpiresAt <= DateTime.UtcNow)
-        {
-            return null;
-        }
-
-        return session.UserId;
+        return authContext.UserId;
     }
 
     public sealed class CreateProjectRequest

--- a/samples/Aegis.Auth.Sample/Controllers/ProjectsController.cs
+++ b/samples/Aegis.Auth.Sample/Controllers/ProjectsController.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 
 using Aegis.Auth.Abstractions;
-using Aegis.Auth.Entities;
 using Aegis.Auth.Extensions;
 using Aegis.Auth.Sample.Data;
 using Aegis.Auth.Sample.Services;

--- a/samples/Aegis.Auth.Sample/Program.cs
+++ b/samples/Aegis.Auth.Sample/Program.cs
@@ -92,6 +92,21 @@ app.MapAegisAuthEndpoints(options =>
     builder.Configuration.GetSection("AegisHttp").Bind(options);
 });
 
+// Custom minimal APIs protected by Aegis auth.
+app.MapGroup("/api/demo")
+    .RequireAegisAuth()
+    .MapGet("/me", (HttpContext httpContext) =>
+    {
+        var authContext = httpContext.GetAegisAuthContext();
+        return Results.Ok(new
+        {
+            authContext!.UserId,
+            authContext.SessionToken,
+            authContext.ExpiresAt,
+            authContext.IsFromCookieCache,
+        });
+    });
+
 Console.WriteLine("🚀 Aegis Auth Sample API is starting...");
 Console.WriteLine("📝 Test credentials:");
 Console.WriteLine("   Email: test@example.com");

--- a/samples/Aegis.Auth.Sample/README.md
+++ b/samples/Aegis.Auth.Sample/README.md
@@ -11,6 +11,8 @@ This is a sample ASP.NET Core Web API project that demonstrates how to use the A
 - ✅ Business domain example (`Projects` + `ProjectTasks`) tied to authenticated user
 - ✅ SQLite database for realistic local persistence
 - ✅ Strongly typed app-specific user extension (`AppUser.IsSpecial`)
+- ✅ Controller protection example via `[AegisAuthorize]`
+- ✅ Minimal API protection example via `.RequireAegisAuth()`
 - ✅ Pre-seeded test user
 
 ## Test Credentials
@@ -80,7 +82,8 @@ Content-Type: application/json
 GET /api/projects/my
 ```
 
-Returns projects owned by the currently authenticated user (resolved from Aegis session cookie).
+Returns projects owned by the currently authenticated user.
+This controller is protected by `[AegisAuthorize]` and reads `HttpContext.GetAegisAuthContext()`.
 
 ```http
 GET /api/projects/my/workspace
@@ -110,6 +113,14 @@ Content-Type: application/json
   "title": "Ship first public beta"
 }
 ```
+
+### Custom Minimal API Behind Authentication
+
+```http
+GET /api/demo/me
+```
+
+Demonstrates user-defined minimal APIs protected with `.RequireAegisAuth()`.
 
 ## Testing with curl
 
@@ -168,7 +179,10 @@ curl http://localhost:5000/api/projects/my -b cookies.txt
 # 3) Read tier/limits for the current user
 curl http://localhost:5000/api/projects/my/workspace -b cookies.txt
 
-# 4) Create a project
+# 4) Read current auth context through a protected minimal API
+curl http://localhost:5000/api/demo/me -b cookies.txt
+
+# 5) Create a project
 curl -X POST http://localhost:5000/api/projects \
   -H "Content-Type: application/json" \
   -d '{"name":"Aegis Demo","description":"Show auth-powered business behavior"}' \
@@ -210,7 +224,11 @@ This lets you remove routes entirely (for example, no sign-up endpoint in produc
 - **Program.cs**: Application configuration and startup
 - **Aegis.Auth.Http**: Package that maps auth endpoints via `app.MapAegisAuthEndpoints()`
 
-The authentication endpoints are minimal APIs in `Aegis.Auth.Http` (not MVC controllers in the sample project).
+The authentication endpoints are minimal APIs in `Aegis.Auth.Http`.
+The sample also demonstrates protecting user-defined routes in both styles:
+
+- Controller style: `[AegisAuthorize]` + `HttpContext.GetAegisAuthContext()`
+- Minimal API style: `.RequireAegisAuth()`
 
 ## Extending User Properties
 

--- a/samples/Aegis.Auth.Sample/Services/ProjectWorkspaceService.cs
+++ b/samples/Aegis.Auth.Sample/Services/ProjectWorkspaceService.cs
@@ -119,7 +119,7 @@ public sealed class ProjectWorkspaceService(SampleAuthDbContext dbContext) : IPr
 
     public async Task<CreateProjectResult?> CreateProjectAsync(string userId, string name, string? description, CancellationToken cancellationToken = default)
     {
-        var profile = await GetTierProfileAsync(userId, cancellationToken);
+        UserTierProfile? profile = await GetTierProfileAsync(userId, cancellationToken);
         if (profile is null)
         {
             return null;
@@ -134,7 +134,7 @@ public sealed class ProjectWorkspaceService(SampleAuthDbContext dbContext) : IPr
             return null;
         }
 
-        var now = DateTime.UtcNow;
+        DateTime now = DateTime.UtcNow;
         var project = new Project
         {
             Id = Guid.CreateVersion7().ToString(),
@@ -185,13 +185,13 @@ public sealed class ProjectWorkspaceService(SampleAuthDbContext dbContext) : IPr
 
     public async Task<AddProjectTaskResult?> AddTaskAsync(string userId, string projectId, string title, CancellationToken cancellationToken = default)
     {
-        var profile = await GetTierProfileAsync(userId, cancellationToken);
+        UserTierProfile? profile = await GetTierProfileAsync(userId, cancellationToken);
         if (profile is null)
         {
             return null;
         }
 
-        var project = await _db.Projects
+        Project? project = await _db.Projects
             .FirstOrDefaultAsync(p => p.Id == projectId && p.OwnerUserId == userId, cancellationToken);
 
         if (project is null)
@@ -208,7 +208,7 @@ public sealed class ProjectWorkspaceService(SampleAuthDbContext dbContext) : IPr
             return null;
         }
 
-        var now = DateTime.UtcNow;
+        DateTime now = DateTime.UtcNow;
         var task = new ProjectTask
         {
             Id = Guid.CreateVersion7().ToString(),

--- a/samples/Aegis.Auth.Sample/sample-requests.json
+++ b/samples/Aegis.Auth.Sample/sample-requests.json
@@ -85,6 +85,10 @@
         "description": "Fetch projects for currently signed-in user",
         "endpoint": "GET /api/projects/my"
     },
+    "getDemoMe": {
+        "description": "Custom minimal API endpoint protected by Aegis auth",
+        "endpoint": "GET /api/demo/me"
+    },
     "createProject": {
         "description": "Create a new business project for signed-in user",
         "endpoint": "POST /api/projects",

--- a/samples/Aegis.Auth.Sample/test-requests.http
+++ b/samples/Aegis.Auth.Sample/test-requests.http
@@ -147,6 +147,13 @@ Cookie: aegis.session={{sessionCookie}}
 
 ###
 
+### Custom protected minimal API: current auth context
+GET {{baseUrl}}/api/demo/me
+Accept: application/json
+Cookie: aegis.session={{sessionCookie}}
+
+###
+
 ### Business: Create a project (requires auth cookie)
 ### @name createProject
 POST {{baseUrl}}/api/projects

--- a/src/Aegis.Auth.Http/Extensions/AegisAuthProtectionExtensions.cs
+++ b/src/Aegis.Auth.Http/Extensions/AegisAuthProtectionExtensions.cs
@@ -1,57 +1,57 @@
 using Aegis.Auth.Abstractions;
 using Aegis.Auth.Extensions;
 
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.Builder;
 
 namespace Aegis.Auth.Http.Extensions;
 
 public static class AegisAuthProtectionExtensions
 {
-  public static RouteGroupBuilder RequireAegisAuth(this RouteGroupBuilder group)
-  {
-    ArgumentNullException.ThrowIfNull(group);
-
-    group.AddEndpointFilter<AegisAuthRequiredEndpointFilter>();
-    return group;
-  }
-
-  public static RouteHandlerBuilder RequireAegisAuth(this RouteHandlerBuilder builder)
-  {
-    ArgumentNullException.ThrowIfNull(builder);
-
-    builder.AddEndpointFilter<AegisAuthRequiredEndpointFilter>();
-    return builder;
-  }
-
-  private sealed class AegisAuthRequiredEndpointFilter : IEndpointFilter
-  {
-    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    public static RouteGroupBuilder RequireAegisAuth(this RouteGroupBuilder group)
     {
-      if (context.HttpContext.RequestServices.GetService(typeof(IAegisAuthContextAccessor)) is not IAegisAuthContextAccessor accessor)
-      {
-        return Results.Problem(
-            title: "Server Misconfiguration",
-            detail: "Aegis auth services are not registered.",
-            statusCode: StatusCodes.Status500InternalServerError,
-            type: "https://httpstatuses.com/500",
-            instance: context.HttpContext.Request.Path);
-      }
+        ArgumentNullException.ThrowIfNull(group);
 
-      AegisAuthContext? authContext = await accessor.GetCurrentAsync(context.HttpContext, context.HttpContext.RequestAborted);
-      if (authContext is null)
-      {
-        return Results.Problem(
-            title: "Unauthorized",
-            detail: "Authentication is required to access this resource.",
-            statusCode: StatusCodes.Status401Unauthorized,
-            type: "https://httpstatuses.com/401",
-            instance: context.HttpContext.Request.Path);
-      }
-
-      context.HttpContext.SetAegisAuthContext(authContext);
-      return await next(context);
+        group.AddEndpointFilter<AegisAuthRequiredEndpointFilter>();
+        return group;
     }
-  }
+
+    public static RouteHandlerBuilder RequireAegisAuth(this RouteHandlerBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddEndpointFilter<AegisAuthRequiredEndpointFilter>();
+        return builder;
+    }
+
+    private sealed class AegisAuthRequiredEndpointFilter : IEndpointFilter
+    {
+        public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+        {
+            if (context.HttpContext.RequestServices.GetService(typeof(IAegisAuthContextAccessor)) is not IAegisAuthContextAccessor accessor)
+            {
+                return Results.Problem(
+                    title: "Server Misconfiguration",
+                    detail: "Aegis auth services are not registered.",
+                    statusCode: StatusCodes.Status500InternalServerError,
+                    type: "https://httpstatuses.com/500",
+                    instance: context.HttpContext.Request.Path);
+            }
+
+            AegisAuthContext? authContext = await accessor.GetCurrentAsync(context.HttpContext, context.HttpContext.RequestAborted);
+            if (authContext is null)
+            {
+                return Results.Problem(
+                    title: "Unauthorized",
+                    detail: "Authentication is required to access this resource.",
+                    statusCode: StatusCodes.Status401Unauthorized,
+                    type: "https://httpstatuses.com/401",
+                    instance: context.HttpContext.Request.Path);
+            }
+
+            context.HttpContext.SetAegisAuthContext(authContext);
+            return await next(context);
+        }
+    }
 }

--- a/src/Aegis.Auth.Http/Extensions/AegisAuthProtectionExtensions.cs
+++ b/src/Aegis.Auth.Http/Extensions/AegisAuthProtectionExtensions.cs
@@ -1,0 +1,57 @@
+using Aegis.Auth.Abstractions;
+using Aegis.Auth.Extensions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Builder;
+
+namespace Aegis.Auth.Http.Extensions;
+
+public static class AegisAuthProtectionExtensions
+{
+  public static RouteGroupBuilder RequireAegisAuth(this RouteGroupBuilder group)
+  {
+    ArgumentNullException.ThrowIfNull(group);
+
+    group.AddEndpointFilter<AegisAuthRequiredEndpointFilter>();
+    return group;
+  }
+
+  public static RouteHandlerBuilder RequireAegisAuth(this RouteHandlerBuilder builder)
+  {
+    ArgumentNullException.ThrowIfNull(builder);
+
+    builder.AddEndpointFilter<AegisAuthRequiredEndpointFilter>();
+    return builder;
+  }
+
+  private sealed class AegisAuthRequiredEndpointFilter : IEndpointFilter
+  {
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+      if (context.HttpContext.RequestServices.GetService(typeof(IAegisAuthContextAccessor)) is not IAegisAuthContextAccessor accessor)
+      {
+        return Results.Problem(
+            title: "Server Misconfiguration",
+            detail: "Aegis auth services are not registered.",
+            statusCode: StatusCodes.Status500InternalServerError,
+            type: "https://httpstatuses.com/500",
+            instance: context.HttpContext.Request.Path);
+      }
+
+      AegisAuthContext? authContext = await accessor.GetCurrentAsync(context.HttpContext, context.HttpContext.RequestAborted);
+      if (authContext is null)
+      {
+        return Results.Problem(
+            title: "Unauthorized",
+            detail: "Authentication is required to access this resource.",
+            statusCode: StatusCodes.Status401Unauthorized,
+            type: "https://httpstatuses.com/401",
+            instance: context.HttpContext.Request.Path);
+      }
+
+      context.HttpContext.SetAegisAuthContext(authContext);
+      return await next(context);
+    }
+  }
+}

--- a/src/Aegis.Auth.Http/Features/SignOut/SignOutEndpoints.cs
+++ b/src/Aegis.Auth.Http/Features/SignOut/SignOutEndpoints.cs
@@ -34,7 +34,7 @@ internal static class SignOutEndpoints
             return Results.Ok(new SignOutResponse { Success = true });
         }
 
-        var result = await signOutService.SignOut(new SignOutInput { Token = token }, cancellationToken);
+        Result result = await signOutService.SignOut(new SignOutInput { Token = token }, cancellationToken);
         if (result.IsSuccess is false)
         {
             return AegisHttpResultMapper.MapError(httpContext, result.ErrorCode, result.Message);

--- a/src/Aegis.Auth.Http/Features/SignUp/SignUpEmailEndpoints.cs
+++ b/src/Aegis.Auth.Http/Features/SignUp/SignUpEmailEndpoints.cs
@@ -40,7 +40,7 @@ internal static class SignUpEmailEndpoints
             IpAddress = httpContext.GetClientIpAddress(),
         };
 
-        var result = await signUpService.SignUpEmail(emailInput, cancellationToken);
+        Result<SignUpResult> result = await signUpService.SignUpEmail(emailInput, cancellationToken);
         if (result.IsSuccess is false || result.Value is null)
         {
             return AegisHttpResultMapper.MapError(httpContext, result.ErrorCode, result.Message);

--- a/src/Aegis.Auth/Abstractions/AegisAuthContext.cs
+++ b/src/Aegis.Auth/Abstractions/AegisAuthContext.cs
@@ -2,8 +2,8 @@ namespace Aegis.Auth.Abstractions;
 
 public sealed class AegisAuthContext
 {
-  public required string UserId { get; init; }
-  public required string SessionToken { get; init; }
-  public required DateTime ExpiresAt { get; init; }
-  public bool IsFromCookieCache { get; init; }
+    public required string UserId { get; init; }
+    public required string SessionToken { get; init; }
+    public required DateTime ExpiresAt { get; init; }
+    public bool IsFromCookieCache { get; init; }
 }

--- a/src/Aegis.Auth/Abstractions/AegisAuthContext.cs
+++ b/src/Aegis.Auth/Abstractions/AegisAuthContext.cs
@@ -1,0 +1,9 @@
+namespace Aegis.Auth.Abstractions;
+
+public sealed class AegisAuthContext
+{
+  public required string UserId { get; init; }
+  public required string SessionToken { get; init; }
+  public required DateTime ExpiresAt { get; init; }
+  public bool IsFromCookieCache { get; init; }
+}

--- a/src/Aegis.Auth/Abstractions/AegisAuthorizeAttribute.cs
+++ b/src/Aegis.Auth/Abstractions/AegisAuthorizeAttribute.cs
@@ -1,0 +1,38 @@
+using Aegis.Auth.Extensions;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Aegis.Auth.Abstractions;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+public sealed class AegisAuthorizeAttribute : Attribute, IAsyncAuthorizationFilter
+{
+  public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
+  {
+    ArgumentNullException.ThrowIfNull(context);
+
+    if (context.HttpContext.RequestServices.GetService(typeof(IAegisAuthContextAccessor)) is not IAegisAuthContextAccessor accessor)
+    {
+      context.Result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
+      return;
+    }
+
+    AegisAuthContext? authContext = await accessor.GetCurrentAsync(context.HttpContext, context.HttpContext.RequestAborted);
+    if (authContext is null)
+    {
+      context.Result = new UnauthorizedObjectResult(new ProblemDetails
+      {
+        Status = StatusCodes.Status401Unauthorized,
+        Title = "Unauthorized",
+        Detail = "Authentication is required to access this resource.",
+        Type = "https://httpstatuses.com/401",
+        Instance = context.HttpContext.Request.Path,
+      });
+      return;
+    }
+
+    context.HttpContext.SetAegisAuthContext(authContext);
+  }
+}

--- a/src/Aegis.Auth/Abstractions/AegisAuthorizeAttribute.cs
+++ b/src/Aegis.Auth/Abstractions/AegisAuthorizeAttribute.cs
@@ -1,7 +1,7 @@
 using Aegis.Auth.Extensions;
 
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace Aegis.Auth.Abstractions;
@@ -9,30 +9,30 @@ namespace Aegis.Auth.Abstractions;
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
 public sealed class AegisAuthorizeAttribute : Attribute, IAsyncAuthorizationFilter
 {
-  public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
-  {
-    ArgumentNullException.ThrowIfNull(context);
-
-    if (context.HttpContext.RequestServices.GetService(typeof(IAegisAuthContextAccessor)) is not IAegisAuthContextAccessor accessor)
+    public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
     {
-      context.Result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
-      return;
-    }
+        ArgumentNullException.ThrowIfNull(context);
 
-    AegisAuthContext? authContext = await accessor.GetCurrentAsync(context.HttpContext, context.HttpContext.RequestAborted);
-    if (authContext is null)
-    {
-      context.Result = new UnauthorizedObjectResult(new ProblemDetails
-      {
-        Status = StatusCodes.Status401Unauthorized,
-        Title = "Unauthorized",
-        Detail = "Authentication is required to access this resource.",
-        Type = "https://httpstatuses.com/401",
-        Instance = context.HttpContext.Request.Path,
-      });
-      return;
-    }
+        if (context.HttpContext.RequestServices.GetService(typeof(IAegisAuthContextAccessor)) is not IAegisAuthContextAccessor accessor)
+        {
+            context.Result = new StatusCodeResult(StatusCodes.Status500InternalServerError);
+            return;
+        }
 
-    context.HttpContext.SetAegisAuthContext(authContext);
-  }
+        AegisAuthContext? authContext = await accessor.GetCurrentAsync(context.HttpContext, context.HttpContext.RequestAborted);
+        if (authContext is null)
+        {
+            context.Result = new UnauthorizedObjectResult(new ProblemDetails
+            {
+                Status = StatusCodes.Status401Unauthorized,
+                Title = "Unauthorized",
+                Detail = "Authentication is required to access this resource.",
+                Type = "https://httpstatuses.com/401",
+                Instance = context.HttpContext.Request.Path,
+            });
+            return;
+        }
+
+        context.HttpContext.SetAegisAuthContext(authContext);
+    }
 }

--- a/src/Aegis.Auth/Abstractions/IAegisAuthContextAccessor.cs
+++ b/src/Aegis.Auth/Abstractions/IAegisAuthContextAccessor.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Aegis.Auth.Abstractions;
+
+public interface IAegisAuthContextAccessor
+{
+  Task<AegisAuthContext?> GetCurrentAsync(HttpContext httpContext, CancellationToken cancellationToken = default);
+}

--- a/src/Aegis.Auth/Abstractions/IAegisAuthContextAccessor.cs
+++ b/src/Aegis.Auth/Abstractions/IAegisAuthContextAccessor.cs
@@ -4,5 +4,5 @@ namespace Aegis.Auth.Abstractions;
 
 public interface IAegisAuthContextAccessor
 {
-  Task<AegisAuthContext?> GetCurrentAsync(HttpContext httpContext, CancellationToken cancellationToken = default);
+    Task<AegisAuthContext?> GetCurrentAsync(HttpContext httpContext, CancellationToken cancellationToken = default);
 }

--- a/src/Aegis.Auth/Extensions/HttpContextAegisAuthExtensions.cs
+++ b/src/Aegis.Auth/Extensions/HttpContextAegisAuthExtensions.cs
@@ -1,0 +1,27 @@
+using Aegis.Auth.Abstractions;
+
+using Microsoft.AspNetCore.Http;
+
+namespace Aegis.Auth.Extensions;
+
+public static class HttpContextAegisAuthExtensions
+{
+  private const string AegisAuthContextItemKey = "aegis.auth.context";
+
+  public static void SetAegisAuthContext(this HttpContext httpContext, AegisAuthContext authContext)
+  {
+    ArgumentNullException.ThrowIfNull(httpContext);
+    ArgumentNullException.ThrowIfNull(authContext);
+
+    httpContext.Items[AegisAuthContextItemKey] = authContext;
+  }
+
+  public static AegisAuthContext? GetAegisAuthContext(this HttpContext httpContext)
+  {
+    ArgumentNullException.ThrowIfNull(httpContext);
+
+    return httpContext.Items.TryGetValue(AegisAuthContextItemKey, out var value)
+        ? value as AegisAuthContext
+        : null;
+  }
+}

--- a/src/Aegis.Auth/Extensions/HttpContextAegisAuthExtensions.cs
+++ b/src/Aegis.Auth/Extensions/HttpContextAegisAuthExtensions.cs
@@ -6,22 +6,22 @@ namespace Aegis.Auth.Extensions;
 
 public static class HttpContextAegisAuthExtensions
 {
-  private const string AegisAuthContextItemKey = "aegis.auth.context";
+    private const string AegisAuthContextItemKey = "aegis.auth.context";
 
-  public static void SetAegisAuthContext(this HttpContext httpContext, AegisAuthContext authContext)
-  {
-    ArgumentNullException.ThrowIfNull(httpContext);
-    ArgumentNullException.ThrowIfNull(authContext);
+    public static void SetAegisAuthContext(this HttpContext httpContext, AegisAuthContext authContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(authContext);
 
-    httpContext.Items[AegisAuthContextItemKey] = authContext;
-  }
+        httpContext.Items[AegisAuthContextItemKey] = authContext;
+    }
 
-  public static AegisAuthContext? GetAegisAuthContext(this HttpContext httpContext)
-  {
-    ArgumentNullException.ThrowIfNull(httpContext);
+    public static AegisAuthContext? GetAegisAuthContext(this HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
 
-    return httpContext.Items.TryGetValue(AegisAuthContextItemKey, out var value)
-        ? value as AegisAuthContext
-        : null;
-  }
+        return httpContext.Items.TryGetValue(AegisAuthContextItemKey, out var value)
+            ? value as AegisAuthContext
+            : null;
+    }
 }

--- a/src/Aegis.Auth/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aegis.Auth/Extensions/ServiceCollectionExtensions.cs
@@ -31,7 +31,7 @@ namespace Aegis.Auth.Extensions
             // Backward compatibility for existing consumers resolving AegisAuthOptions directly.
             services.AddSingleton(sp => sp.GetRequiredService<IOptions<AegisAuthOptions>>().Value);
 
-            // Register AegisCookieManager
+            // Register cookie handler
             services.AddScoped(sp =>
             {
                 IHostEnvironment env = sp.GetRequiredService<IHostEnvironment>();

--- a/src/Aegis.Auth/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aegis.Auth/Extensions/ServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Aegis.Auth.Features.Sessions;
 using Aegis.Auth.Features.SignIn;
 using Aegis.Auth.Features.SignOut;
 using Aegis.Auth.Features.SignUp;
+using Aegis.Auth.Infrastructure.Auth;
 using Aegis.Auth.Infrastructure.Cookies;
 using Aegis.Auth.Options;
 
@@ -46,6 +47,7 @@ namespace Aegis.Auth.Extensions
             services.AddScoped<ISignInService, SignInService>();
             services.AddScoped<ISignUpService, SignUpService>();
             services.AddScoped<ISignOutService, SignOutService>();
+            services.AddScoped<IAegisAuthContextAccessor, AegisAuthContextAccessor>();
 
             return services;
         }

--- a/src/Aegis.Auth/Features/Sessions/SessionService.cs
+++ b/src/Aegis.Auth/Features/Sessions/SessionService.cs
@@ -91,14 +91,10 @@ namespace Aegis.Auth.Features.Sessions
                         var currentListJson = await _cache.GetStringAsync(registryKey, cancellationToken);
 
                         List<SessionReference> list = [];
-                        if (string.IsNullOrWhiteSpace(currentListJson) is false)
+                        if (TryDeserializeSessionReferences(currentListJson, out List<SessionReference>? cachedList))
                         {
-                            List<SessionReference>? cachedList = JsonSerializer.Deserialize<List<SessionReference>>(currentListJson);
-                            if (cachedList is not null)
-                            {
-                                // Filter: remove expired and duplicates
-                                list = [.. cachedList.Where(s => s.ExpiresAt > nowUnixMs && s.Token != data.Token)];
-                            }
+                            // Filter: remove expired and duplicates
+                            list = [.. cachedList!.Where(s => s.ExpiresAt > nowUnixMs && s.Token != data.Token)];
                         }
 
                         // 2. Add new session and sort
@@ -117,8 +113,8 @@ namespace Aegis.Auth.Features.Sessions
                             var verifyJson = await _cache.GetStringAsync(registryKey, cancellationToken);
                             if (!string.IsNullOrWhiteSpace(verifyJson))
                             {
-                                List<SessionReference>? verifyList = JsonSerializer.Deserialize<List<SessionReference>>(verifyJson);
-                                if (verifyList?.Any(s => s.Token == data.Token) == true)
+
+                                if (TryDeserializeSessionReferences(verifyJson, out List<SessionReference>? verifyList) && verifyList?.Any(s => s.Token == data.Token) == true)
                                 {
                                     registryUpdated = true;
                                 }
@@ -169,36 +165,32 @@ namespace Aegis.Auth.Features.Sessions
                 var registryKey = RegistryKeyPrefix + input.User.Id;
                 var registryJson = await _cache.GetStringAsync(registryKey, cancellationToken);
 
-                if (string.IsNullOrWhiteSpace(registryJson) is false)
+                if (TryDeserializeSessionReferences(registryJson, out List<SessionReference>? list))
                 {
-                    List<SessionReference>? list = JsonSerializer.Deserialize<List<SessionReference>>(registryJson);
-                    if (list is not null)
-                    {
-                        var nowUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-                        // Remove the revoked session and any expired ones
-                        list = [.. list.Where(s => s.Token != token && s.ExpiresAt > nowUnixMs)];
+                    var nowUnixMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+                    // Remove the revoked session and any expired ones
+                    list = [.. list!.Where(s => s.Token != token && s.ExpiresAt > nowUnixMs)];
 
-                        if (list.Count == 0)
+                    if (list.Count == 0)
+                    {
+                        // No sessions left — delete the key entirely (Redis-friendly)
+                        await _cache.RemoveAsync(registryKey, cancellationToken);
+                    }
+                    else
+                    {
+                        // Recalculate TTL based on the furthest-expiring remaining session (round up)
+                        list.Sort((a, b) => a.ExpiresAt.CompareTo(b.ExpiresAt));
+                        var furthestExp = list[^1].ExpiresAt;
+                        var ttlSeconds = (long)Math.Ceiling((furthestExp - nowUnixMs) / 1000.0);
+
+                        if (ttlSeconds > 0)
                         {
-                            // No sessions left — delete the key entirely (Redis-friendly)
-                            await _cache.RemoveAsync(registryKey, cancellationToken);
+                            await _cache.SetStringAsync(registryKey, JsonSerializer.Serialize(list),
+                                                                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(ttlSeconds) }, cancellationToken);
                         }
                         else
                         {
-                            // Recalculate TTL based on the furthest-expiring remaining session (round up)
-                            list.Sort((a, b) => a.ExpiresAt.CompareTo(b.ExpiresAt));
-                            var furthestExp = list[^1].ExpiresAt;
-                            var ttlSeconds = (long)Math.Ceiling((furthestExp - nowUnixMs) / 1000.0);
-
-                            if (ttlSeconds > 0)
-                            {
-                                await _cache.SetStringAsync(registryKey, JsonSerializer.Serialize(list),
-                                                                    new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(ttlSeconds) }, cancellationToken);
-                            }
-                            else
-                            {
-                                await _cache.RemoveAsync(registryKey, cancellationToken);
-                            }
+                            await _cache.RemoveAsync(registryKey, cancellationToken);
                         }
                     }
                 }
@@ -237,21 +229,17 @@ namespace Aegis.Auth.Features.Sessions
                 var registryKey = RegistryKeyPrefix + userId;
                 var registryJson = await _cache.GetStringAsync(registryKey, cancellationToken);
 
-                if (string.IsNullOrWhiteSpace(registryJson) is false)
+                if (TryDeserializeSessionReferences(registryJson, out List<SessionReference>? list))
                 {
-                    List<SessionReference>? list = JsonSerializer.Deserialize<List<SessionReference>>(registryJson);
-                    if (list is not null)
+                    // Remove each cached session
+                    foreach (SessionReference entry in list!)
                     {
-                        // Remove each cached session
-                        foreach (SessionReference entry in list)
-                        {
-                            await _cache.RemoveAsync(entry.Token, cancellationToken);
-                        }
+                        await _cache.RemoveAsync(entry.Token, cancellationToken);
                     }
-
-                    // Delete the registry key itself
-                    await _cache.RemoveAsync(registryKey, cancellationToken);
                 }
+
+                // Delete the registry key itself
+                await _cache.RemoveAsync(registryKey, cancellationToken);
             }
 
             // 2. Remove all from database
@@ -275,6 +263,26 @@ namespace Aegis.Auth.Features.Sessions
 
             _logger.SessionRevokedAll(userId);
             return Result.Success();
+        }
+
+        private static bool TryDeserializeSessionReferences(string? json, out List<SessionReference>? list)
+        {
+            list = null;
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            try
+            {
+                list = JsonSerializer.Deserialize<List<SessionReference>>(json);
+                return list is not null;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/Aegis.Auth/Features/Sessions/SessionService.cs
+++ b/src/Aegis.Auth/Features/Sessions/SessionService.cs
@@ -117,7 +117,7 @@ namespace Aegis.Auth.Features.Sessions
                             var verifyJson = await _cache.GetStringAsync(registryKey, cancellationToken);
                             if (!string.IsNullOrWhiteSpace(verifyJson))
                             {
-                                var verifyList = JsonSerializer.Deserialize<List<SessionReference>>(verifyJson);
+                                List<SessionReference>? verifyList = JsonSerializer.Deserialize<List<SessionReference>>(verifyJson);
                                 if (verifyList?.Any(s => s.Token == data.Token) == true)
                                 {
                                     registryUpdated = true;

--- a/src/Aegis.Auth/Infrastructure/Auth/AegisAuthContextAccessor.cs
+++ b/src/Aegis.Auth/Infrastructure/Auth/AegisAuthContextAccessor.cs
@@ -10,50 +10,50 @@ namespace Aegis.Auth.Infrastructure.Auth;
 
 internal sealed class AegisAuthContextAccessor(SessionCookieHandler cookieHandler, IAuthDbContext dbContext) : IAegisAuthContextAccessor
 {
-  private readonly SessionCookieHandler _cookieHandler = cookieHandler;
-  private readonly IAuthDbContext _db = dbContext;
+    private readonly SessionCookieHandler _cookieHandler = cookieHandler;
+    private readonly IAuthDbContext _db = dbContext;
 
-  public async Task<AegisAuthContext?> GetCurrentAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
-  {
-    ArgumentNullException.ThrowIfNull(httpContext);
-
-    string? sessionToken = _cookieHandler.GetSessionToken(httpContext);
-    if (string.IsNullOrWhiteSpace(sessionToken))
+    public async Task<AegisAuthContext?> GetCurrentAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
     {
-      return null;
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        string? sessionToken = _cookieHandler.GetSessionToken(httpContext);
+        if (string.IsNullOrWhiteSpace(sessionToken))
+        {
+            return null;
+        }
+
+        // Fast path: prefer validated cookie cache when available.
+        SessionCacheMetadata? cookieCache = _cookieHandler.GetCookieCache(httpContext);
+        if (cookieCache is not null
+            && string.Equals(cookieCache.Session.Token, sessionToken, StringComparison.Ordinal)
+            && cookieCache.Session.ExpiresAt > DateTime.UtcNow
+            && string.IsNullOrWhiteSpace(cookieCache.User.Id) is false)
+        {
+            return new AegisAuthContext
+            {
+                UserId = cookieCache.User.Id,
+                SessionToken = sessionToken,
+                ExpiresAt = cookieCache.Session.ExpiresAt,
+                IsFromCookieCache = true,
+            };
+        }
+
+        Session? session = await _db.Sessions
+        .AsNoTracking()
+        .FirstOrDefaultAsync(s => s.Token == sessionToken, cancellationToken);
+
+        if (session is null || session.ExpiresAt <= DateTime.UtcNow)
+        {
+            return null;
+        }
+
+        return new AegisAuthContext
+        {
+            UserId = session.UserId,
+            SessionToken = session.Token,
+            ExpiresAt = session.ExpiresAt,
+            IsFromCookieCache = false,
+        };
     }
-
-    // Fast path: prefer validated cookie cache when available.
-    SessionCacheMetadata? cookieCache = _cookieHandler.GetCookieCache(httpContext);
-    if (cookieCache is not null
-        && string.Equals(cookieCache.Session.Token, sessionToken, StringComparison.Ordinal)
-        && cookieCache.Session.ExpiresAt > DateTime.UtcNow
-        && string.IsNullOrWhiteSpace(cookieCache.User.Id) is false)
-    {
-      return new AegisAuthContext
-      {
-        UserId = cookieCache.User.Id,
-        SessionToken = sessionToken,
-        ExpiresAt = cookieCache.Session.ExpiresAt,
-        IsFromCookieCache = true,
-      };
-    }
-
-    Session? session = await _db.Sessions
-    .AsNoTracking()
-    .FirstOrDefaultAsync(s => s.Token == sessionToken, cancellationToken);
-
-    if (session is null || session.ExpiresAt <= DateTime.UtcNow)
-    {
-      return null;
-    }
-
-    return new AegisAuthContext
-    {
-      UserId = session.UserId,
-      SessionToken = session.Token,
-      ExpiresAt = session.ExpiresAt,
-      IsFromCookieCache = false,
-    };
-  }
 }

--- a/src/Aegis.Auth/Infrastructure/Auth/AegisAuthContextAccessor.cs
+++ b/src/Aegis.Auth/Infrastructure/Auth/AegisAuthContextAccessor.cs
@@ -1,0 +1,59 @@
+using Aegis.Auth.Abstractions;
+using Aegis.Auth.Entities;
+using Aegis.Auth.Infrastructure.Cookies;
+using Aegis.Auth.Models;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Aegis.Auth.Infrastructure.Auth;
+
+internal sealed class AegisAuthContextAccessor(SessionCookieHandler cookieHandler, IAuthDbContext dbContext) : IAegisAuthContextAccessor
+{
+  private readonly SessionCookieHandler _cookieHandler = cookieHandler;
+  private readonly IAuthDbContext _db = dbContext;
+
+  public async Task<AegisAuthContext?> GetCurrentAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
+  {
+    ArgumentNullException.ThrowIfNull(httpContext);
+
+    string? sessionToken = _cookieHandler.GetSessionToken(httpContext);
+    if (string.IsNullOrWhiteSpace(sessionToken))
+    {
+      return null;
+    }
+
+    // Fast path: prefer validated cookie cache when available.
+    SessionCacheMetadata? cookieCache = _cookieHandler.GetCookieCache(httpContext);
+    if (cookieCache is not null
+        && string.Equals(cookieCache.Session.Token, sessionToken, StringComparison.Ordinal)
+        && cookieCache.Session.ExpiresAt > DateTime.UtcNow
+        && string.IsNullOrWhiteSpace(cookieCache.User.Id) is false)
+    {
+      return new AegisAuthContext
+      {
+        UserId = cookieCache.User.Id,
+        SessionToken = sessionToken,
+        ExpiresAt = cookieCache.Session.ExpiresAt,
+        IsFromCookieCache = true,
+      };
+    }
+
+    Session? session = await _db.Sessions
+    .AsNoTracking()
+    .FirstOrDefaultAsync(s => s.Token == sessionToken, cancellationToken);
+
+    if (session is null || session.ExpiresAt <= DateTime.UtcNow)
+    {
+      return null;
+    }
+
+    return new AegisAuthContext
+    {
+      UserId = session.UserId,
+      SessionToken = session.Token,
+      ExpiresAt = session.ExpiresAt,
+      IsFromCookieCache = false,
+    };
+  }
+}

--- a/src/Aegis.Auth/Infrastructure/Auth/AegisAuthContextAccessor.cs
+++ b/src/Aegis.Auth/Infrastructure/Auth/AegisAuthContextAccessor.cs
@@ -17,7 +17,7 @@ internal sealed class AegisAuthContextAccessor(SessionCookieHandler cookieHandle
     {
         ArgumentNullException.ThrowIfNull(httpContext);
 
-        string? sessionToken = _cookieHandler.GetSessionToken(httpContext);
+        var sessionToken = _cookieHandler.GetSessionToken(httpContext);
         if (string.IsNullOrWhiteSpace(sessionToken))
         {
             return null;

--- a/src/Aegis.Auth/Infrastructure/Cookies/SessionCookieHandler.cs
+++ b/src/Aegis.Auth/Infrastructure/Cookies/SessionCookieHandler.cs
@@ -163,9 +163,7 @@ namespace Aegis.Auth.Infrastructure.Cookies
                 Session = envelope.Session
             };
             var signableJson = JsonSerializer.Serialize(signableEnvelope);
-            var expectedSignature = AegisSigner.GenerateSignature(signableJson, _options.Secret);
-
-            if (envelope.Signature != expectedSignature)
+            if (!AegisSigner.VerifySignature(signableJson, envelope.Signature, _options.Secret))
                 return null;
 
             return envelope.Session.Session;

--- a/tests/Aegis.Auth.Tests/Features/AuthContextAccessorTests.cs
+++ b/tests/Aegis.Auth.Tests/Features/AuthContextAccessorTests.cs
@@ -11,98 +11,98 @@ namespace Aegis.Auth.Tests.Features;
 
 public sealed class AuthContextAccessorTests : IDisposable
 {
-  private readonly ServiceTestFixture _fixture;
-  private readonly SessionCookieHandler _cookieHandler;
-  private readonly IAegisAuthContextAccessor _sut;
+    private readonly ServiceTestFixture _fixture;
+    private readonly SessionCookieHandler _cookieHandler;
+    private readonly IAegisAuthContextAccessor _sut;
 
-  public AuthContextAccessorTests()
-  {
-    _fixture = new ServiceTestFixture();
-    _cookieHandler = new SessionCookieHandler(_fixture.Options, isDevelopment: true);
-    _sut = new AegisAuthContextAccessor(_cookieHandler, _fixture.DbContext);
-  }
-
-  public void Dispose() => _fixture.Dispose();
-
-  [Fact]
-  public async Task GetCurrentAsync_ValidSignedCookieAndSession_ReturnsAuthContext()
-  {
-    (User user, _) = await _fixture.SeedUserAsync();
-    Session session = await SeedSessionAsync(user, token: "valid-token");
-
-    DefaultHttpContext httpContext = CreateHttpContextWithSessionCookie("valid-token");
-
-    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
-
-    Assert.NotNull(context);
-    Assert.Equal(user.Id, context!.UserId);
-    Assert.Equal(session.Token, context.SessionToken);
-    Assert.False(context.IsFromCookieCache);
-  }
-
-  [Fact]
-  public async Task GetCurrentAsync_MissingCookie_ReturnsNull()
-  {
-    var httpContext = new DefaultHttpContext();
-
-    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
-
-    Assert.Null(context);
-  }
-
-  [Fact]
-  public async Task GetCurrentAsync_TamperedCookieSignature_ReturnsNull()
-  {
-    (User user, _) = await _fixture.SeedUserAsync();
-    await SeedSessionAsync(user, token: "valid-token");
-
-    var httpContext = new DefaultHttpContext();
-    httpContext.Request.Headers.Cookie = "aegis.session=valid-token.invalid-signature";
-
-    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
-
-    Assert.Null(context);
-  }
-
-  [Fact]
-  public async Task GetCurrentAsync_ExpiredSession_ReturnsNull()
-  {
-    (User user, _) = await _fixture.SeedUserAsync();
-    await SeedSessionAsync(user, token: "expired-token", expiresAt: DateTime.UtcNow.AddMinutes(-5));
-
-    DefaultHttpContext httpContext = CreateHttpContextWithSessionCookie("expired-token");
-
-    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
-
-    Assert.Null(context);
-  }
-
-  private DefaultHttpContext CreateHttpContextWithSessionCookie(string token)
-  {
-    var signedToken = AegisSigner.Sign(token, _fixture.Options.Secret);
-
-    var httpContext = new DefaultHttpContext();
-    httpContext.Request.Headers.Cookie = $"aegis.session={signedToken}";
-    return httpContext;
-  }
-
-  private async Task<Session> SeedSessionAsync(User user, string token, DateTime? expiresAt = null)
-  {
-    var session = new Session
+    public AuthContextAccessorTests()
     {
-      Id = Guid.CreateVersion7().ToString(),
-      Token = token,
-      ExpiresAt = expiresAt ?? DateTime.UtcNow.AddDays(7),
-      UserId = user.Id,
-      User = user,
-      IpAddress = "127.0.0.1",
-      UserAgent = "TestAgent/1.0",
-      CreatedAt = DateTime.UtcNow,
-      UpdatedAt = DateTime.UtcNow,
-    };
+        _fixture = new ServiceTestFixture();
+        _cookieHandler = new SessionCookieHandler(_fixture.Options, isDevelopment: true);
+        _sut = new AegisAuthContextAccessor(_cookieHandler, _fixture.DbContext);
+    }
 
-    _fixture.DbContext.Sessions.Add(session);
-    await _fixture.DbContext.SaveChangesAsync();
-    return session;
-  }
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public async Task GetCurrentAsync_ValidSignedCookieAndSession_ReturnsAuthContext()
+    {
+        (User user, _) = await _fixture.SeedUserAsync();
+        Session session = await SeedSessionAsync(user, token: "valid-token");
+
+        DefaultHttpContext httpContext = CreateHttpContextWithSessionCookie("valid-token");
+
+        AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+        Assert.NotNull(context);
+        Assert.Equal(user.Id, context!.UserId);
+        Assert.Equal(session.Token, context.SessionToken);
+        Assert.False(context.IsFromCookieCache);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_MissingCookie_ReturnsNull()
+    {
+        var httpContext = new DefaultHttpContext();
+
+        AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+        Assert.Null(context);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_TamperedCookieSignature_ReturnsNull()
+    {
+        (User user, _) = await _fixture.SeedUserAsync();
+        await SeedSessionAsync(user, token: "valid-token");
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Cookie = "aegis.session=valid-token.invalid-signature";
+
+        AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+        Assert.Null(context);
+    }
+
+    [Fact]
+    public async Task GetCurrentAsync_ExpiredSession_ReturnsNull()
+    {
+        (User user, _) = await _fixture.SeedUserAsync();
+        await SeedSessionAsync(user, token: "expired-token", expiresAt: DateTime.UtcNow.AddMinutes(-5));
+
+        DefaultHttpContext httpContext = CreateHttpContextWithSessionCookie("expired-token");
+
+        AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+        Assert.Null(context);
+    }
+
+    private DefaultHttpContext CreateHttpContextWithSessionCookie(string token)
+    {
+        var signedToken = AegisSigner.Sign(token, _fixture.Options.Secret);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers.Cookie = $"aegis.session={signedToken}";
+        return httpContext;
+    }
+
+    private async Task<Session> SeedSessionAsync(User user, string token, DateTime? expiresAt = null)
+    {
+        var session = new Session
+        {
+            Id = Guid.CreateVersion7().ToString(),
+            Token = token,
+            ExpiresAt = expiresAt ?? DateTime.UtcNow.AddDays(7),
+            UserId = user.Id,
+            User = user,
+            IpAddress = "127.0.0.1",
+            UserAgent = "TestAgent/1.0",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+
+        _fixture.DbContext.Sessions.Add(session);
+        await _fixture.DbContext.SaveChangesAsync();
+        return session;
+    }
 }

--- a/tests/Aegis.Auth.Tests/Features/AuthContextAccessorTests.cs
+++ b/tests/Aegis.Auth.Tests/Features/AuthContextAccessorTests.cs
@@ -3,6 +3,7 @@ using Aegis.Auth.Core.Crypto;
 using Aegis.Auth.Entities;
 using Aegis.Auth.Infrastructure.Auth;
 using Aegis.Auth.Infrastructure.Cookies;
+using Aegis.Auth.Options;
 using Aegis.Auth.Tests.Helpers;
 
 using Microsoft.AspNetCore.Http;
@@ -77,6 +78,35 @@ public sealed class AuthContextAccessorTests : IDisposable
         Assert.Null(context);
     }
 
+    [Fact]
+    public async Task GetCurrentAsync_ValidCookieCache_ReturnsAuthContextFromCookieCache()
+    {
+        using var fixture = new ServiceTestFixture(options =>
+        {
+            options.Session.CookieCache = new CookieCacheOptions
+            {
+                Enabled = true,
+                MaxAge = 300,
+            };
+        });
+
+        var cookieHandler = new SessionCookieHandler(fixture.Options, isDevelopment: true);
+        IAegisAuthContextAccessor sut = new AegisAuthContextAccessor(cookieHandler, fixture.DbContext);
+
+        (User user, _) = await fixture.SeedUserAsync();
+        Session session = await SeedSessionAsync(fixture, user, token: "cached-token");
+
+        DefaultHttpContext httpContext = CreateHttpContextWithSessionCookies(cookieHandler, session, user);
+
+        AegisAuthContext? context = await sut.GetCurrentAsync(httpContext);
+
+        Assert.NotNull(context);
+        Assert.Equal(user.Id, context!.UserId);
+        Assert.Equal(session.Token, context.SessionToken);
+        Assert.Equal(session.ExpiresAt, context.ExpiresAt);
+        Assert.True(context.IsFromCookieCache);
+    }
+
     private DefaultHttpContext CreateHttpContextWithSessionCookie(string token)
     {
         var signedToken = AegisSigner.Sign(token, _fixture.Options.Secret);
@@ -86,7 +116,27 @@ public sealed class AuthContextAccessorTests : IDisposable
         return httpContext;
     }
 
-    private async Task<Session> SeedSessionAsync(User user, string token, DateTime? expiresAt = null)
+    private static DefaultHttpContext CreateHttpContextWithSessionCookies(SessionCookieHandler cookieHandler, Session session, User user)
+    {
+        var responseContext = new DefaultHttpContext();
+        cookieHandler.SetSessionCookie(responseContext, session, user, rememberMe: true);
+
+        var requestCookies = responseContext.Response.Headers.SetCookie
+            .Select(static cookie => (cookie ?? string.Empty).Split(';', 2)[0])
+            .Where(static cookie => string.IsNullOrWhiteSpace(cookie) is false)
+            .ToArray();
+
+        var cookieHeader = string.Join("; ", requestCookies);
+
+        var requestContext = new DefaultHttpContext();
+        requestContext.Request.Headers.Cookie = cookieHeader;
+        return requestContext;
+    }
+
+    private Task<Session> SeedSessionAsync(User user, string token, DateTime? expiresAt = null)
+        => SeedSessionAsync(_fixture, user, token, expiresAt);
+
+    private static async Task<Session> SeedSessionAsync(ServiceTestFixture fixture, User user, string token, DateTime? expiresAt = null)
     {
         var session = new Session
         {
@@ -101,8 +151,8 @@ public sealed class AuthContextAccessorTests : IDisposable
             UpdatedAt = DateTime.UtcNow,
         };
 
-        _fixture.DbContext.Sessions.Add(session);
-        await _fixture.DbContext.SaveChangesAsync();
+        fixture.DbContext.Sessions.Add(session);
+        await fixture.DbContext.SaveChangesAsync();
         return session;
     }
 }

--- a/tests/Aegis.Auth.Tests/Features/AuthContextAccessorTests.cs
+++ b/tests/Aegis.Auth.Tests/Features/AuthContextAccessorTests.cs
@@ -1,0 +1,108 @@
+using Aegis.Auth.Abstractions;
+using Aegis.Auth.Core.Crypto;
+using Aegis.Auth.Entities;
+using Aegis.Auth.Infrastructure.Auth;
+using Aegis.Auth.Infrastructure.Cookies;
+using Aegis.Auth.Tests.Helpers;
+
+using Microsoft.AspNetCore.Http;
+
+namespace Aegis.Auth.Tests.Features;
+
+public sealed class AuthContextAccessorTests : IDisposable
+{
+  private readonly ServiceTestFixture _fixture;
+  private readonly SessionCookieHandler _cookieHandler;
+  private readonly IAegisAuthContextAccessor _sut;
+
+  public AuthContextAccessorTests()
+  {
+    _fixture = new ServiceTestFixture();
+    _cookieHandler = new SessionCookieHandler(_fixture.Options, isDevelopment: true);
+    _sut = new AegisAuthContextAccessor(_cookieHandler, _fixture.DbContext);
+  }
+
+  public void Dispose() => _fixture.Dispose();
+
+  [Fact]
+  public async Task GetCurrentAsync_ValidSignedCookieAndSession_ReturnsAuthContext()
+  {
+    (User user, _) = await _fixture.SeedUserAsync();
+    Session session = await SeedSessionAsync(user, token: "valid-token");
+
+    DefaultHttpContext httpContext = CreateHttpContextWithSessionCookie("valid-token");
+
+    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+    Assert.NotNull(context);
+    Assert.Equal(user.Id, context!.UserId);
+    Assert.Equal(session.Token, context.SessionToken);
+    Assert.False(context.IsFromCookieCache);
+  }
+
+  [Fact]
+  public async Task GetCurrentAsync_MissingCookie_ReturnsNull()
+  {
+    var httpContext = new DefaultHttpContext();
+
+    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+    Assert.Null(context);
+  }
+
+  [Fact]
+  public async Task GetCurrentAsync_TamperedCookieSignature_ReturnsNull()
+  {
+    (User user, _) = await _fixture.SeedUserAsync();
+    await SeedSessionAsync(user, token: "valid-token");
+
+    var httpContext = new DefaultHttpContext();
+    httpContext.Request.Headers.Cookie = "aegis.session=valid-token.invalid-signature";
+
+    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+    Assert.Null(context);
+  }
+
+  [Fact]
+  public async Task GetCurrentAsync_ExpiredSession_ReturnsNull()
+  {
+    (User user, _) = await _fixture.SeedUserAsync();
+    await SeedSessionAsync(user, token: "expired-token", expiresAt: DateTime.UtcNow.AddMinutes(-5));
+
+    DefaultHttpContext httpContext = CreateHttpContextWithSessionCookie("expired-token");
+
+    AegisAuthContext? context = await _sut.GetCurrentAsync(httpContext);
+
+    Assert.Null(context);
+  }
+
+  private DefaultHttpContext CreateHttpContextWithSessionCookie(string token)
+  {
+    var signedToken = AegisSigner.Sign(token, _fixture.Options.Secret);
+
+    var httpContext = new DefaultHttpContext();
+    httpContext.Request.Headers.Cookie = $"aegis.session={signedToken}";
+    return httpContext;
+  }
+
+  private async Task<Session> SeedSessionAsync(User user, string token, DateTime? expiresAt = null)
+  {
+    var session = new Session
+    {
+      Id = Guid.CreateVersion7().ToString(),
+      Token = token,
+      ExpiresAt = expiresAt ?? DateTime.UtcNow.AddDays(7),
+      UserId = user.Id,
+      User = user,
+      IpAddress = "127.0.0.1",
+      UserAgent = "TestAgent/1.0",
+      CreatedAt = DateTime.UtcNow,
+      UpdatedAt = DateTime.UtcNow,
+    };
+
+    _fixture.DbContext.Sessions.Add(session);
+    await _fixture.DbContext.SaveChangesAsync();
+    return session;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable auth protection extension for custom endpoints in Aegis.Auth.Http
- introduce auth context abstractions and accessor implementation in Aegis.Auth
- add HTTP context auth extensions for downstream consumer ergonomics
- improve session and cookie handling robustness, including session registry verification path
- update sample app endpoints, docs, and request examples to reflect auth-protection usage
- add tests for auth context accessor behavior

## Changed areas
- src/Aegis.Auth.Http endpoint/auth protection extensions
- src/Aegis.Auth abstractions, extensions, session/cookie infrastructure
- samples/Aegis.Auth.Sample wiring, endpoints, docs, and request files
- tests/Aegis.Auth.Tests auth context accessor coverage

## Validation
- branch rebased/merged cleanly after conflict resolution
- no unresolved merge conflicts remain
- tests/build not run in this step
